### PR TITLE
Expose default namespace object.

### DIFF
--- a/blinker/__init__.py
+++ b/blinker/__init__.py
@@ -6,6 +6,7 @@ from blinker.base import (
     WeakNamespace,
     receiver_connected,
     signal,
+    namespace,
 )
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     'WeakNamespace',
     'receiver_connected',
     'signal',
+    'namespace',
     ]
 
 

--- a/blinker/base.py
+++ b/blinker/base.py
@@ -452,4 +452,5 @@ class WeakNamespace(WeakValueDictionary):
             return self.setdefault(name, NamedSignal(name, doc))
 
 
-signal = Namespace().signal
+namespace = Namespace()
+signal = namespace.signal


### PR DESCRIPTION
This also supports diagnostic utilities that inspect the global namespace. This also makes it convenient to write consistent code that is parameterized on a namespace, but that still functions with the global namespace. Additionally, _not_ exposing the global namespace encourages writing codes that refers to it only implicitly, which is more painful to refactor later.

In those use cases, the alternative to library users is something brittle like:

``` py
from blinker import signal

namespace = signal.im_self
```

For additional discussion, see the original PR #23 
