### PR TITLE
convert readme from Markdown to ReST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
-include README.md
+include README.rst
 include AUTHORS
 include CHANGES
 recursive-include tests *py

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,15 @@
-[![Build Status](https://travis-ci.org/jek/blinker.svg?branch=master)](https://travis-ci.org/jek/blinker)
+|Build Status|
 
-
-# Blinker
+Blinker
+=======
 
 Blinker provides a fast dispatching system that allows any number of
-interested parties to subscribe to events, or "signals".
+interested parties to subscribe to events, or “signals”.
 
 Signal receivers can subscribe to specific senders or receive signals
 sent by any sender.
+
+::
 
     >>> from blinker import signal
     >>> started = signal('round-started')
@@ -15,12 +17,12 @@ sent by any sender.
     ...     print "Round %s!" % round
     ...
     >>> started.connect(each)
-    
+
     >>> def round_two(round):
     ...     print "This is round two."
     ...
     >>> started.connect(round_two, sender=2)
-  
+
     >>> for round in range(1, 4):
     ...     started.send(round)
     ...
@@ -29,44 +31,53 @@ sent by any sender.
     This is round two.
     Round 3!
 
-See the [Blinker documentation](https://pythonhosted.org/blinker/) for more information.
+See the `Blinker documentation`_ for more information.
 
-## Requirements
+Requirements
+------------
 
-Blinker requires Python 2.4 or higher, Python 3.0 or higher, or Jython 2.5 or higher.
+Blinker requires Python 2.4 or higher, Python 3.0 or higher, or Jython
+2.5 or higher.
 
-## Changelog Summary
+Changelog Summary
+-----------------
 
 1.3 (July 3, 2013)
 
- - The global signal stash behind blinker.signal() is now backed by a
+-  The global signal stash behind blinker.signal() is now backed by a
    regular name-to-Signal dictionary. Previously, weak references were
    held in the mapping and ephemeral usage in code like
    ``signal('foo').connect(...)`` could have surprising program behavior
    depending on import order of modules.
- - blinker.Namespace is now built on a regular dict. Use
+-  blinker.Namespace is now built on a regular dict. Use
    blinker.WeakNamespace for the older, weak-referencing behavior.
- - Signal.connect('text-sender') uses an alternate hashing strategy to
+-  Signal.connect(‘text-sender’) uses an alternate hashing strategy to
    avoid sharp edges in text identity.
 
 1.2 (October 26, 2011)
 
- - Added Signal.receiver_connected and Signal.receiver_disconnected
+-  Added Signal.receiver\_connected and Signal.receiver\_disconnected
    per-Signal signals.
- - Deprecated the global 'receiver_connected' signal.
- - Verified Python 3.2 support (no changes needed!)
+-  Deprecated the global ‘receiver\_connected’ signal.
+-  Verified Python 3.2 support (no changes needed!)
 
 1.1 (July 21, 2010)
 
- - Added ``@signal.connect_via(sender)`` decorator
- - Added ``signal.connected_to`` shorthand name for the
+-  Added ``@signal.connect_via(sender)`` decorator
+-  Added ``signal.connected_to`` shorthand name for the
    ``temporarily_connected_to`` context manager.
 
 1.0 (March 28, 2010)
 
- - Python 3.x compatibility
+-  Python 3.x compatibility
 
 0.9 (February 26, 2010)
 
- - Sphinx docs, project website
- - Added ``with a_signal.temporarily_connected_to(receiver): ...`` support
+-  Sphinx docs, project website
+-  Added ``with a_signal.temporarily_connected_to(receiver): ...``
+   support 
+
+.. _Blinker documentation: https://pythonhosted.org/blinker/
+
+.. |Build Status| image:: https://travis-ci.org/jek/blinker.svg?branch=master
+   :target: https://travis-ci.org/jek/blinker

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ Changelog Summary
 0.9 (February 26, 2010)
 
 -  Sphinx docs, project website
--  Added ``with a_signal.temporarily_connected_to(receiver): ...``
-   support 
+-  Added ``with a_signal.temporarily_connected_to(receiver): ...`` support
+
 
 .. _Blinker documentation: https://pythonhosted.org/blinker/
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ interested parties to subscribe to events, or “signals”.
 Signal receivers can subscribe to specific senders or receive signals
 sent by any sender.
 
-::
+.. code-block:: python
 
     >>> from blinker import signal
     >>> started = signal('round-started')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-readme = open('README.md').read()
+readme = open('README.rst').read()
 import blinker
 version = blinker.__version__
 


### PR DESCRIPTION
Simple PR for fixing issue #15 
- README has been converted to rst
- (bonus) add syntax highlighting for the example in the README
