### PR TITLE
Add support for standard test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,6 @@ setup(name="blinker",
           'Topic :: Software Development :: Libraries',
           'Topic :: Utilities',
           ],
+          tests_require=['nose'],
+          test_suite='nose.collector',
 )


### PR DESCRIPTION
This change adds support for running the standard/canonical test command, as per the nose integration documentation [1]. It additionally uses the standard tests_requires to install test dependencies automatically.

This is super useful for users and other downstream consumers (like OS packagers / porters)

You may want to tweak your tox command configuration to use this rather that nosetests.

[1] http://nose.readthedocs.org/en/latest/setuptools_integration.html
