### PR TITLE
Slightly safer version-based checking for bound method

### DIFF
--- a/blinker/_utilities.py
+++ b/blinker/_utilities.py
@@ -1,3 +1,4 @@
+import sys
 from weakref import ref
 
 from blinker._saferef import BoundMethodWeakref
@@ -8,6 +9,12 @@ try:
 except NameError:
     def callable(object):
         return hasattr(object, '__call__')
+
+
+if sys.version_info < (3,):
+    self_attr_name = 'im_self'
+else:
+    self_attr_name = '__self__'
 
 
 try:
@@ -141,9 +148,7 @@ def reference(object, callback=None, **annotations):
 
 def callable_reference(object, callback=None):
     """Return an annotated weak ref, supporting bound instance methods."""
-    if hasattr(object, 'im_self') and object.im_self is not None:
-        return BoundMethodWeakref(target=object, on_delete=callback)
-    elif hasattr(object, '__self__') and object.__self__ is not None:
+    if hasattr(object, self_attr_name) and getattr(object, self_attr_name) is not None:
         return BoundMethodWeakref(target=object, on_delete=callback)
     return annotatable_weakref(object, callback)
 


### PR DESCRIPTION
Utilities file was discriminating between different attributes for bound method with `hasattr`function but Saferef file was doing it with version-based discrimination.

It can cause problems if `hasattr`and getting the attribute returned not-`None`object - e.g. when you are inheriting from `Events`class (which `python-eve` does) but you are actually using Python 3+. In that case, `utilities`will find `im_self`attribute (Events create all the attributes non-starting with `__`on-the-fly) but `saferef`file looks at the version number and tries to get `__self__`attribute. Which may not be (in `python-eve` case it is not) defined.

This PR unifies the approach to version-based
