### PR TITLE
Temporarily mute signal

### DIFF
--- a/blinker/base.py
+++ b/blinker/base.py
@@ -224,6 +224,9 @@ class Signal(object):
 
     @contextmanager
     def muted(self):
+        """Context manager for temporarily disabling signal.
+        Useful for test purposes.
+        """
         self.is_muted = True
         try:
             yield None

--- a/blinker/base.py
+++ b/blinker/base.py
@@ -85,6 +85,7 @@ class Signal(object):
         #: of the mapping is useful as an extremely efficient check to see if
         #: any receivers are connected to the signal.
         self.receivers = {}
+        self.is_muted = False
         self._by_receiver = defaultdict(set)
         self._by_sender = defaultdict(set)
         self._weak_senders = {}
@@ -220,6 +221,18 @@ class Signal(object):
         else:
             self.disconnect(receiver)
 
+
+    @contextmanager
+    def muted(self):
+        self.is_muted = True
+        try:
+            yield None
+        except:
+            raise
+        finally:
+            self.is_muted = False
+
+
     def temporarily_connected_to(self, receiver, sender=ANY):
         """An alias for :meth:`connected_to`.
 
@@ -260,7 +273,7 @@ class Signal(object):
                             '%s given' % len(sender))
         else:
             sender = sender[0]
-        if not self.receivers:
+        if self.is_muted or not self.receivers:
             return []
         else:
             return [(receiver, receiver(sender, **kwargs))

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -483,6 +483,22 @@ def test_named_blinker():
     assert 'squiznart' in repr(sig)
 
 
+def test_mute_signal():
+    sentinel = []
+    def received(sender):
+        sentinel.append(sender)
+
+    sig = blinker.Signal()
+    sig.connect(received)
+
+    sig.send(123)
+    assert 123 in sentinel
+
+    with sig.muted():
+        sig.send(456)
+    assert 456 not in sentinel
+
+
 def values_are_empty_sets_(dictionary):
     for val in dictionary.values():
         assert val == set()


### PR DESCRIPTION
Sometimes you need to switch off particular signals for testing purposes. I guess this context manager would be more convenient way to solve such task:

``` python
# I have some signal
signal = blinker.Signal()

sig.send(123)  # it's been sent

with sig.muted():
    sig.send(456)  # it's muted and hasn't been sent
```
