### PR TITLE
Call signal receivers in the order they were first registered

### DIFF
--- a/blinker/_utilities.py
+++ b/blinker/_utilities.py
@@ -56,6 +56,12 @@ except:
             return 'defaultdict(%s, %s)' % (self.default_factory,
                                             dict.__repr__(self))
 
+try:
+    from collections import OrderedDict
+except:
+    from ordereddict import OrderedDict
+
+from orderedset import OrderedSet
 
 try:
     from contextlib import contextmanager

--- a/blinker/base.py
+++ b/blinker/base.py
@@ -19,6 +19,8 @@ from blinker._utilities import (
     lazy_property,
     reference,
     symbol,
+    OrderedDict,
+    OrderedSet
     )
 
 
@@ -84,9 +86,9 @@ class Signal(object):
         #: internal :class:`Signal` implementation, however the boolean value
         #: of the mapping is useful as an extremely efficient check to see if
         #: any receivers are connected to the signal.
-        self.receivers = {}
-        self._by_receiver = defaultdict(set)
-        self._by_sender = defaultdict(set)
+        self.receivers = OrderedDict()
+        self._by_receiver = defaultdict(OrderedSet)
+        self._by_sender = defaultdict(OrderedSet)
         self._weak_senders = {}
 
     def connect(self, receiver, sender=ANY, weak=True):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -192,7 +192,7 @@ be used as a decorator on functions:
   >>> apc = AltProcessor('c')
   >>> @apc.on_complete.connect
   ... def completed(sender):
-  ...     print "AltProcessor %s completed!" % sender.name
+  ...     print("AltProcessor %s completed!" % sender.name)
   ...
   >>> apc.go()
   Alternate processing.

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,37 @@ except ImportError:
     from distutils.core import setup
 
 readme = open('README.md').read()
-import blinker
-version = blinker.__version__
+
+def find_version(*file_paths):
+    """
+    Don't pull version by importing package as it will be broken due to as-yet uninstalled
+    dependencies, following recommendations at  https://packaging.python.org/single_source_version,
+    extract directly from the init file
+    """
+    import os
+    import re
+    import io
+    def read(*names, **kwargs):
+        with io.open(
+                os.path.join(os.path.dirname(__file__), *names),
+                encoding=kwargs.get("encoding", "utf8")
+        ) as fp:
+            return fp.read()
+
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+version = find_version("blinker", "__init__.py")
+
+
+requirements = ['orderedset>=1.1.1']
+import sys
+if sys.version_info < (2, 7):
+    requirements += ['ordereddict>=1.1']
 
 setup(name="blinker",
       version=version,
@@ -17,6 +46,7 @@ setup(name="blinker",
       long_description=readme,
       license='MIT License',
       url='http://pythonhosted.org/blinker/',
+      install_requires=requirements,
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',


### PR DESCRIPTION
## Problem statement:

I'm using pelican, and have a set of plugins that I'd like to apply -- pelican uses blinker as its primary extension mechanism to handle lifecycle hooks.

Since one plugin relies on another (or at least can recognize and make use of their results), they need to be applied in a set order. Ideally, they should be applied in the order specified in plugin load order. Otherwise they are applied in random or inconsistent order. 

The current system doesn't guarantee ordering.

## This change set

To make this change required the use of an ordered set and ordered dictionary.

* I've added a dependency to the project for python versions older than 2.7 to polyfill collections.OrderedDict (handled in setup.py and proxied via _utilities)

* I've added an implementation of orderedsets, the implementation has broad support across python
versions, but indicates it should work back to only python 2.6 (would require a bump in minimum version)

All signals are connected via ordered variants of the existing structures.

Dispatch is done in an ordered fashion, with receivers being notified in the order the were first added (regardless of how many times they hold connections via different sender filters)

## Desirable outcomes

I think this is a mainline-appropriate feature. Since the library specified arbitrary order, this change should not break any existing code. Adding a strong/predictable ordering does have predictability benefits and should reduce phantom bugs that occur only occasionally because of random ordering.

See the comment on the last commit for a potential weakness of this implementation. If you have any general feedback or insight into why it would be desirable to keep the unordered implementation, I'm interested.

Whether or not this is pulled into mainline, I would like this feature for my own use, if anyone else ends up using this fork and ends up here - I welcome any additional requests or fixes you might find.

