### PR TITLE
Allow int senders

### DIFF
--- a/blinker/_utilities.py
+++ b/blinker/_utilities.py
@@ -117,6 +117,8 @@ def hashable_identity(obj):
         return (id(obj.im_func), id(obj.im_self))
     elif isinstance(obj, text):
         return obj
+    elif isinstance(obj, int):
+        return obj
     else:
         return id(obj)
 


### PR DESCRIPTION
In the same way you can use strings as senders, using ints would be helpful.