### PR TITLE
@asyncio.coroutine --> async def

### DIFF
--- a/blinker/_async.py
+++ b/blinker/_async.py
@@ -9,8 +9,7 @@ except AttributeError:
     schedule = asyncio.ensure_future
 
 
-@asyncio.coroutine
-def _wrap_plain_value(value):
+async def _wrap_plain_value(value):
     """Pass through a coroutine *value* or wrap a plain value."""
     if asyncio.iscoroutine(value):
         value = yield from value
@@ -25,4 +24,3 @@ def send_async(self, *sender, **kwargs):
 
 send_async.__doc__ = Signal.send_async.__doc__
 Signal.send_async = send_async
-

--- a/tests/_test_async.py
+++ b/tests/_test_async.py
@@ -6,13 +6,11 @@ import blinker
 def test_send_async():
     calls = []
 
-    @asyncio.coroutine
-    def receiver_a(sender):
+    async def receiver_a(sender):
         calls.append(receiver_a)
         return 'value a'
 
-    @asyncio.coroutine
-    def receiver_b(sender):
+    async def receiver_b(sender):
         calls.append(receiver_b)
         return 'value b'
 
@@ -25,8 +23,7 @@ def test_send_async():
     sig.connect(receiver_b)
     sig.connect(receiver_c)
 
-    @asyncio.coroutine
-    def collect():
+    async def collect():
         return sig.send_async()
 
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
% `pytest --doctest-modules .`
```
============================= test session starts ==============================

[ ... ]

=============================== warnings summary ===============================
blinker/_async.py:13
  /home/runner/work/blinker/blinker/blinker/_async.py:13: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _wrap_plain_value(value):

../../../../../opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/util/docutils.py:15
  /opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/util/docutils.py:15: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import LooseVersion

tests/test_signals.py::test_send_async
  /home/runner/work/blinker/blinker/tests/_test_async.py:10: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def receiver_a(sender):

tests/test_signals.py::test_send_async
  /home/runner/work/blinker/blinker/tests/_test_async.py:15: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def receiver_b(sender):

tests/test_signals.py::test_send_async
  /home/runner/work/blinker/blinker/tests/_test_async.py:29: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def collect():

tests/test_signals.py::test_send_async
  /home/runner/work/blinker/blinker/tests/_test_async.py:32: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop()

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================== 30 passed, 6 warnings in 0.47s ========================
```