### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(name="blinker",
       long_description=readme,
       license='MIT License',
       url='https://pythonhosted.org/blinker/',
+      project_urls={
+        'Source': 'https://github.com/jek/blinker',
+      },
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.