### PR TITLE
Allow int senders

### DIFF
--- a/src/blinker/_utilities.py
+++ b/src/blinker/_utilities.py
@@ -47,7 +47,7 @@ def hashable_identity(obj):
         return (id(obj.__func__), id(obj.__self__))
     elif hasattr(obj, "im_func"):
         return (id(obj.im_func), id(obj.im_self))
-    elif isinstance(obj, str):
+    elif isinstance(obj, (int, str)):
         return obj
     else:
         return id(obj)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -515,3 +515,18 @@ def test_named_blinker():
 def values_are_empty_sets_(dictionary):
     for val in dictionary.values():
         assert val == set()
+
+
+def test_int_sender():
+    sentinel = []
+
+    def received(sender):
+        sentinel.append(sender)
+
+    sig = blinker.Signal()
+
+    sig.connect(received, sender=123456789)
+    sig.send(123456789)
+    assert len(sentinel) == 1
+    sig.send(123456789 + 0)  # Forces a new id with CPython
+    assert len(sentinel) == 2


### PR DESCRIPTION
This allows int values as senders much in the same way string values are allowed.

Closes #30