### PR TITLE
Added `muted` context manager for temproary switching signal off

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -157,6 +157,19 @@ value``) pairs:
   [(<function receive_data at 0x...>, 'received!')]
 
 
+Muting signals
+--------------
+
+To mute a signal, as may be required when testing, the
+:meth:`~Signal.muted` can be used as a context decorator:
+
+.. code-block:: python
+
+  sig = signal('send-data')
+  with sig.muted():
+       ...
+
+
 Anonymous Signals
 -----------------
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -512,6 +512,23 @@ def test_named_blinker():
     assert "squiznart" in repr(sig)
 
 
+def test_mute_signal():
+    sentinel = []
+
+    def received(sender):
+        sentinel.append(sender)
+
+    sig = blinker.Signal()
+    sig.connect(received)
+
+    sig.send(123)
+    assert 123 in sentinel
+
+    with sig.muted():
+        sig.send(456)
+    assert 456 not in sentinel
+
+
 def values_are_empty_sets_(dictionary):
     for val in dictionary.values():
         assert val == set()


### PR DESCRIPTION
This is useful whilst testing to remove a signal's affects.