### PR TITLE
Run receivers in the order they were connected

### DIFF
--- a/src/blinker/_utilities.py
+++ b/src/blinker/_utilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from itertools import chain
 import sys
 import typing as t
 from functools import partial
@@ -140,3 +141,16 @@ def is_coroutine_function(func: t.Any) -> bool:
 
         acic = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined]
         return getattr(func, "_is_coroutine", None) is acic
+
+
+def merge_lists_unique(*lists):
+    """
+    Merge multiple lists, maintaining order and ensuring items are unique
+    """
+    output = []
+
+    for item in chain.from_iterable(lists):
+        if item not in output:
+            output.append(item)
+
+    return output

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,6 +1,7 @@
 import pickle
 
 from blinker._utilities import symbol
+from blinker._utilities import merge_lists_unique
 
 
 def test_symbols():
@@ -22,3 +23,10 @@ def test_pickled_symbols():
     for _ in 0, 1, 2:
         roundtrip = pickle.loads(pickle.dumps(foo))
         assert roundtrip is foo
+
+
+def test_merge_lists_unique():
+    assert merge_lists_unique([123]) == [123]
+    assert merge_lists_unique([123], [456]) == [123, 456]
+    assert merge_lists_unique([123, 456], [456]) == [123, 456]
+    assert merge_lists_unique([123, 456], [456, 123]) == [123, 456]


### PR DESCRIPTION
This makes it easier to reason about the order in which events happen.

This follows Django's signals, which also maintain order: https://github.com/django/django/blob/main/django/dispatch/dispatcher.py#L39

This is a similar implementation of https://github.com/pallets-eco/blinker/pull/34/, but more robust and without external dependencies