### PR TITLE
Include package data in the distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ warn_return_any = true
 
 [tool.setuptools]
 license-files = ["LICENSE.rst"]
-include-package-data = false
 
 [tool.setuptools.dynamic]
 version = {attr = "blinker.__version__"}


### PR DESCRIPTION
This will ensure the py.typed file is included, and hence the type hints can be used by other projects.