### PR TITLE
Fix Python 3.12 tests

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@
 #
 #    pip-compile-multi
 #
-cachetools==5.2.1
+cachetools==5.3.0
     # via tox
 cfgv==3.3.1
     # via pre-commit
@@ -15,13 +15,13 @@ colorama==0.4.6
     # via tox
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-identify==2.5.13
+identify==2.5.23
     # via pre-commit
-importlib-metadata==6.0.0
+importlib-metadata==6.6.0
     # via
     #   pluggy
     #   pre-commit
@@ -29,11 +29,11 @@ importlib-metadata==6.0.0
     #   virtualenv
 nodeenv==1.7.0
     # via pre-commit
-packaging==23.0
+packaging==23.1
     # via
     #   pyproject-api
     #   tox
-platformdirs==2.6.2
+platformdirs==3.5.0
     # via
     #   tox
     #   virtualenv
@@ -41,7 +41,7 @@ pluggy==1.0.0
     # via tox
 pre-commit==2.21.0
     # via -r requirements/dev.in
-pyproject-api==1.5.0
+pyproject-api==1.5.1
     # via tox
 pyyaml==6.0
     # via pre-commit
@@ -49,18 +49,18 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.3.5
+tox==4.5.1
     # via -r requirements/dev.in
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   importlib-metadata
     #   platformdirs
     #   tox
-virtualenv==20.17.1
+virtualenv==20.23.0
     # via
     #   pre-commit
     #   tox
-zipp==3.11.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,11 +7,11 @@
 #
 alabaster==0.7.13
     # via sphinx
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 docutils==0.19
     # via sphinx
@@ -19,36 +19,40 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==6.6.0
+    # via
+    #   pallets-sphinx-themes
+    #   sphinx
 jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.2
     # via jinja2
-packaging==23.0
+packaging==23.1
     # via
     #   pallets-sphinx-themes
     #   sphinx
 pallets-sphinx-themes==2.0.3
     # via -r requirements/docs.in
-pygments==2.14.0
+pygments==2.15.1
     # via sphinx
-pytz==2022.7.1
+pytz==2023.3
     # via babel
-requests==2.28.2
+requests==2.29.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.1.3
+sphinx==5.3.0
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes
     #   sphinx-issues
 sphinx-issues==3.0.1
     # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -56,5 +60,9 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.14
+typing-extensions==4.5.0
+    # via importlib-metadata
+urllib3==1.26.15
     # via requests
+zipp==3.15.0
+    # via importlib-metadata

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,31 +5,29 @@
 #
 #    pip-compile-multi
 #
-attrs==22.2.0
+exceptiongroup==1.1.1
     # via pytest
-exceptiongroup==1.1.0
-    # via pytest
-importlib-metadata==6.0.0
+importlib-metadata==6.6.0
     # via
     #   pluggy
     #   pytest
 iniconfig==2.0.0
     # via pytest
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
-pytest==7.2.1
+pytest==7.3.1
     # via
     #   -r requirements/tests.in
     #   pytest-asyncio
-pytest-asyncio==0.20.3
+pytest-asyncio==0.21.0
     # via -r requirements/tests.in
 tomli==2.0.1
     # via pytest
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   importlib-metadata
     #   pytest-asyncio
-zipp==3.11.0
+zipp==3.15.0
     # via importlib-metadata

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -5,9 +5,13 @@
 #
 #    pip-compile-multi
 #
-mypy==1.0.1
+mypy==1.2.0
     # via -r requirements/typing.in
 mypy-extensions==1.0.0
+    # via mypy
+tomli==2.0.1
+    # via mypy
+typed-ast==1.5.4
     # via mypy
 typing-extensions==4.5.0
     # via mypy


### PR DESCRIPTION
Python 3.12 tests were failing due to following error:

```
'TestCaseFunction' object has no attribute 'addDuration'
```

\[[Link to sample CI error](https://github.com/pallets-eco/blinker/actions/runs/4683157374/jobs/8297904915#step:6:67)\]

This error is addressed in pytest 7.3.1.

`pip-compile-multi` was run from a Python 3.7 environment on Linux, which updated all of the `requirements/*` files and bumped the pytest version from 7.2.1 to 7.3.1.