### PR TITLE
Signal.connected_to should always disconnect the receiver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Version 1.6.3
 Unreleased
 
 -   Fix `SyncWrapperType` and `AsyncWrapperType` :pr:`108`
+-   Fixed issue where ``signal.connected_to`` would not disconnect the
+    receiver if an instance of ``BaseException`` was raised. :pr:`114`
 
 Version 1.6.2
 -------------

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -229,10 +229,7 @@ class Signal:
         self.connect(receiver, sender=sender, weak=False)
         try:
             yield None
-        except Exception as e:
-            self.disconnect(receiver)
-            raise e
-        else:
+        finally:
             self.disconnect(receiver)
 
     @contextmanager


### PR DESCRIPTION
Bug introduced by 33a14971c34fcd15deb2b18b50c9bd411eb6ed74 which replaced

    try:
        yield None
    except:
        self.disconnect(receiver)
        raise
    else:
        self.disconnect(receiver)

with

    try:
        yield None
    except Exception as e:
        self.disconnect(receiver)
        raise
    else:
        self.disconnect(receiver)

which are not semantically the same, as the latter does not disconnect the receiver if an instance of BaseException is raised. Notably, asyncio.CancelledError is a subclass of BaseException on Python 3.8+