### PR TITLE
Allow the Signal set_class to be customised

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -335,6 +335,24 @@ event loop the following example can be used:
    await sig.send(_async_wrapper=wrapper)
 
 
+Call receivers in order of registration
+---------------------------------------
+
+It can be advantageous to call a signal's receivers in the order they
+were registered. To achieve this the storage class for receivers should
+be changed from an (unordered) set to an ordered set,
+
+.. code-block:: python
+
+    from blinker import Signal
+    from ordered_set import OrderedSet
+
+    Signal.set_class = OrderedSet
+
+Please note that ``ordered_set`` is a PyPI package and is not
+installed with blinker.
+
+
 API Documentation
 -----------------
 

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -47,6 +47,8 @@ class Signal:
     #: without an additional import.
     ANY = ANY
 
+    set_class: type[set] = set
+
     @lazy_property
     def receiver_connected(self) -> Signal:
         """Emitted after each :meth:`connect`.
@@ -99,8 +101,12 @@ class Signal:
         #: any receivers are connected to the signal.
         self.receivers: dict[IdentityType, t.Callable | annotatable_weakref] = {}
         self.is_muted = False
-        self._by_receiver: dict[IdentityType, set[IdentityType]] = defaultdict(set)
-        self._by_sender: dict[IdentityType, set[IdentityType]] = defaultdict(set)
+        self._by_receiver: dict[IdentityType, set[IdentityType]] = defaultdict(
+            self.set_class
+        )
+        self._by_sender: dict[IdentityType, set[IdentityType]] = defaultdict(
+            self.set_class
+        )
         self._weak_senders: dict[IdentityType, annotatable_weakref] = {}
 
     def connect(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -44,7 +44,7 @@ class BaseFailure(BaseException):
     pass
 
 
-@pytest.mark.parametrize('exc_type', [Failure, BaseFailure])
+@pytest.mark.parametrize("exc_type", [Failure, BaseFailure])
 def test_temp_connection_failure(exc_type):
     sig = Signal()
 


### PR DESCRIPTION
This allows an easy way for receivers to be called in registration order, as is often desired by users of the library.