### PR TITLE
Fix deployment issue and re-release 1.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ license = {file = "LICENSE.rst"}
 authors = [{name = "Jason Kirtland", email = "jek@discorporate.us"}]
 maintainers = [{name = "Pallets Ecosystem", email = "contact@palletsprojects.com"}]
 description = "Fast, simple object-to-object and broadcast signaling"
+readme = "README.rst"
 keywords = [
     "signal",
     "emit",


### PR DESCRIPTION
A long_description is required for the project to be published, the README.rst is used for this. Tested with twine check.