### PR TITLE
Fix weakref callback errors during finalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 1.6.4
+-------------
+
+Unreleased
+
+-   Fixed messages printed to standard error about unraisable exceptions during
+    signal cleanup, typically during interpreter shutdown. :pr:`123`
+
 Version 1.6.3
 -------------
 

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -39,6 +39,10 @@ ANY = symbol("ANY")
 ANY.__doc__ = 'Token for "any sender".'
 ANY_ID = 0
 
+# NOTE: We need a reference to cast for use in weakref callbacks otherwise
+#       t.cast may have already been set to None during finalization.
+cast = t.cast
+
 
 class Signal:
     """A notification emitter."""
@@ -427,11 +431,11 @@ class Signal:
 
     def _cleanup_receiver(self, receiver_ref: annotatable_weakref) -> None:
         """Disconnect a receiver from all senders."""
-        self._disconnect(t.cast(IdentityType, receiver_ref.receiver_id), ANY_ID)
+        self._disconnect(cast(IdentityType, receiver_ref.receiver_id), ANY_ID)
 
     def _cleanup_sender(self, sender_ref: annotatable_weakref) -> None:
         """Disconnect all receivers from a sender."""
-        sender_id = t.cast(IdentityType, sender_ref.sender_id)
+        sender_id = cast(IdentityType, sender_ref.sender_id)
         assert sender_id != ANY_ID
         self._weak_senders.pop(sender_id, None)
         for receiver_id in self._by_sender.pop(sender_id, ()):


### PR DESCRIPTION
Using blinker 1.6.3, I get a lot of errors like the following when invoking the Flask CLI, running tests, etc.

```
Exception ignored in: <bound method Signal._cleanup_receiver of <blinker.base.NamedSignal object at 0x10a67ef90; 'request-started'>>
Traceback (most recent call last):
  File "/path/to/venv/lib/python3.7/site-packages/blinker/base.py", line 430, in _cleanup_receiver
TypeError: 'NoneType' object is not callable
```

The only issue I could find about this is one made for sentry: https://github.com/getsentry/sentry-python/issues/2183

I found that the cause is on this line:

https://github.com/pallets-eco/blinker/blob/36560da2976fdef6072929224ea21a16c0c5b9d2/src/blinker/base.py#L430

During cleanup, `t.cast` is `None`.

weakref finalization callbacks need to follow `__del__` rules, i.e.
any globals referenced may have had their attributes set to `None`.