### PR TITLE
update deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Unreleased
 
 -   Deprecate the ``__version__`` attribute. Use feature detection, or
     ``importlib.metadata.version("blinker")``, instead. :issue:`128`
+-   Specify that the deprecated ``temporarily_connected_to`` will be removed in
+    the next version.
+-   Show a deprecation warning for the deprecated global ``receiver_connected``
+    signal and specify that it will be removed in the next version.
 
 
 Version 1.7.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -268,9 +268,6 @@ documentation will be picked up by most documentation generators (such
 as sphinx) and is nice for documenting any additional data parameters
 that will be sent down with the signal.
 
-See the documentation of the :obj:`receiver_connected` built-in signal
-for an example.
-
 
 Async receivers
 ---------------
@@ -366,8 +363,6 @@ Basic Signals
 +++++++++++++
 
 .. autodata:: blinker.base.ANY
-
-.. autodata:: blinker.base.receiver_connected
 
 .. autoclass:: Signal
    :members:

--- a/src/blinker/__init__.py
+++ b/src/blinker/__init__.py
@@ -5,7 +5,6 @@ import typing as t
 from blinker.base import ANY
 from blinker.base import NamedSignal
 from blinker.base import Namespace
-from blinker.base import receiver_connected
 from blinker.base import Signal
 from blinker.base import signal
 from blinker.base import WeakNamespace
@@ -16,15 +15,15 @@ __all__ = [
     "Namespace",
     "Signal",
     "WeakNamespace",
-    "receiver_connected",
     "signal",
 ]
 
 
 def __getattr__(name: str) -> t.Any:
+    import warnings
+
     if name == "__version__":
         import importlib.metadata
-        import warnings
 
         warnings.warn(
             "The '__version__' attribute is deprecated and will be removed in"
@@ -34,5 +33,17 @@ def __getattr__(name: str) -> t.Any:
             stacklevel=2,
         )
         return importlib.metadata.version("blinker")
+
+    if name == "receiver_connected":
+        from .base import _receiver_connected
+
+        warnings.warn(
+            "The global 'receiver_connected' signal is deprecated and will be"
+            " removed in Blinker 1.9. Use 'Signal.receiver_connected' and"
+            " 'Signal.receiver_disconnected' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _receiver_connected
 
     raise AttributeError(name)


### PR DESCRIPTION
The global `receiver_connected` singnal, and the `Signal.temporarily_connected_to` method, were both marked as deprecated but either did not show a deprecation warning or did not specify a removal date. Show a deprecation warning for each and specify that they will be removed in 1.9.
