### PR TITLE
expose the default signal namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
     signal and specify that it will be removed in the next version.
 -   Greatly simplify how the library uses weakrefs. This is a significant change
     internally but should not affect any public API. :pr:`144`
+-   Expose the namespace used by ``signal()`` as ``default_namespace``.
+    :pr:`145`
 
 
 Version 1.7.0

--- a/src/blinker/__init__.py
+++ b/src/blinker/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from .base import ANY
+from .base import default_namespace
 from .base import NamedSignal
 from .base import Namespace
 from .base import Signal
@@ -11,11 +12,12 @@ from .base import WeakNamespace
 
 __all__ = [
     "ANY",
+    "default_namespace",
     "NamedSignal",
     "Namespace",
     "Signal",
-    "WeakNamespace",
     "signal",
+    "WeakNamespace",
 ]
 
 

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -546,7 +546,15 @@ class WeakNamespace(WeakValueDictionary):  # type: ignore[type-arg]
             return result  # type: ignore[no-any-return]
 
 
-signal = Namespace().signal
+default_namespace = Namespace()
+"""A default namespace for creating named signals. :func:`signal` creates a
+signal in this namespace.
+"""
+
+signal = default_namespace.signal
+"""Create a named signal in :data:`default_namespace`. Repeated calls with
+the same name will return the same signal.
+"""
 
 
 def __getattr__(name: str) -> t.Any:


### PR DESCRIPTION
Expose the default `Namespace` used by `signal`. As explained in #24 (which was too old to merge), this makes it easier to work with named signals and namespaces consistently.
