### PR TITLE
deprecate `WeakNamespace`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     the next version.
 -   Show a deprecation warning for the deprecated global ``receiver_connected``
     signal and specify that it will be removed in the next version.
+-   Show a deprecation warning for the deprecated ``WeakNamespace`` and specify
+    that it will be removed in the next version.
 -   Greatly simplify how the library uses weakrefs. This is a significant change
     internally but should not affect any public API. :pr:`144`
 -   Expose the namespace used by ``signal()`` as ``default_namespace``.

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -531,7 +531,19 @@ class WeakNamespace(WeakValueDictionary):  # type: ignore[type-arg]
     compatibility with Blinker <= 1.2, and may be dropped in the future.
 
     .. versionadded:: 1.3
+
+    .. deprecated:: 1.3
+        Will be removed in Blinker 1.9.
     """
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "'WeakNamespace' is deprecated and will be removed in Blinker 1.9."
+            " Use 'Namespace' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()
 
     def signal(self, name: str, doc: str | None = None) -> NamedSignal:
         """Return the :class:`NamedSignal` *name*, creating it if required.

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -200,23 +200,6 @@ def test_empty_bucket_growth() -> None:
     assert receivers() == (0, 0)
 
 
-def test_weak_namespace() -> None:
-    ns = blinker.WeakNamespace()
-    assert not ns
-    s1 = ns.signal("abc")
-    assert s1 is ns.signal("abc")
-    assert s1 is not ns.signal("def")
-    assert "abc" in ns
-    collect_acyclic_refs()
-
-    # weak by default, already out of scope
-    assert "def" not in ns
-    del s1
-    collect_acyclic_refs()
-
-    assert "abc" not in ns
-
-
 def test_namespace() -> None:
     ns = blinker.Namespace()
     assert not ns


### PR DESCRIPTION
`WeakNamespace` was added as a transitition from older Blinker behavior, and immediately documented as "will be removed later", but did not raise a deprecation warning. It now shows a deprecation warning for its removal in 1.9.
