### PR TITLE
fix deprecated WeakNamespace import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 1.8.1
 Unreleased
 
 -   Restore identity handling for ``str`` and ``int`` senders. :pr:`148`
+-   Fix deprecated `blinker.base.WeakNamespace` import. :pr:`149`
 
 
 Version 1.8.0

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -587,5 +587,6 @@ def __getattr__(name: str) -> t.Any:
             DeprecationWarning,
             stacklevel=2,
         )
+        return _WeakNamespace
 
     raise AttributeError(name)


### PR DESCRIPTION
Forgot to actually return the object when showing the deprecation warning for `blinker.base.WeakNamespace`. The more likely `blinker.WeakNamespace` import worked correctly, but still need to fix this.
