### PR TITLE
use collections.abc instead of typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Version 1.8.1
 Unreleased
 
 -   Restore identity handling for ``str`` and ``int`` senders. :pr:`148`
--   Fix deprecated `blinker.base.WeakNamespace` import. :pr:`149`
+-   Fix deprecated ``blinker.base.WeakNamespace`` import. :pr:`149`
+-   Use types from ``collections.abc`` instead of ``typing``. :pr:`150`
 
 
 Version 1.8.0

--- a/src/blinker/_utilities.py
+++ b/src/blinker/_utilities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as c
 import inspect
 import typing as t
 from weakref import ref
@@ -34,11 +35,11 @@ class Symbol:
     def __repr__(self) -> str:
         return self.name
 
-    def __getnewargs__(self) -> tuple[t.Any]:
+    def __getnewargs__(self) -> tuple[t.Any, ...]:
         return (self.name,)
 
 
-def make_id(obj: object) -> t.Hashable:
+def make_id(obj: object) -> c.Hashable:
     """Get a stable identifier for a receiver or sender, to be used as a dict
     key or in a set.
     """
@@ -56,7 +57,7 @@ def make_id(obj: object) -> t.Hashable:
     return id(obj)
 
 
-def make_ref(obj: T, callback: t.Callable[[ref[T]], None] | None = None) -> ref[T]:
+def make_ref(obj: T, callback: c.Callable[[ref[T]], None] | None = None) -> ref[T]:
     if inspect.ismethod(obj):
         return WeakMethod(obj, callback)  # type: ignore[arg-type, return-value]
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as c
 import gc
 import sys
 import typing as t
@@ -18,7 +19,7 @@ def collect_acyclic_refs() -> None:
 class Sentinel(list):  # type: ignore[type-arg]
     """A signal receipt accumulator."""
 
-    def make_receiver(self, key: t.Any) -> t.Callable[..., t.Any]:
+    def make_receiver(self, key: t.Any) -> c.Callable[..., t.Any]:
         """Return a generic signal receiver function logging as *key*
 
         When connected to a signal, appends (key, sender, kw) to the Sentinel.
@@ -265,7 +266,7 @@ async def test_async_receiver() -> None:
     def received(sender: t.Any) -> None:
         sentinel.append(sender)
 
-    def wrapper(func: t.Callable[..., t.Any]) -> t.Callable[..., None]:
+    def wrapper(func: c.Callable[..., t.Any]) -> c.Callable[..., None]:
         async def inner(*args: t.Any, **kwargs: t.Any) -> None:
             func(*args, **kwargs)
 


### PR DESCRIPTION
Use types from `collections.abc` instead of `typing` for compatility when the `typing` aliases are finally removed.
