### PR TITLE
pass `pyright --verifytypes`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 -   Restore identity handling for ``str`` and ``int`` senders. :pr:`148`
 -   Fix deprecated ``blinker.base.WeakNamespace`` import. :pr:`149`
 -   Use types from ``collections.abc`` instead of ``typing``. :pr:`150`
+-   Fully specify exported types as reported by pyright. :pr:`152`
 
 
 Version 1.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps = -r requirements/typing.txt
 commands =
     mypy
     pyright
+    pyright --verifytypes blinker --ignoreexternal
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
Fully specify exported types to satisfy `pyright --verifytypes blinker --ignoreexternal`. This required a trick to use a typed `dict[]` base class since that's not supported until Python 3.9.
