### PR TITLE
fix deprecated receiver_connected import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 
 -   Restore identity handling for ``str`` and ``int`` senders. :pr:`148`
 -   Fix deprecated ``blinker.base.WeakNamespace`` import. :pr:`149`
+-   Fix deprecated ``blinker.base.receiver_connected import``. :pr:`153`
 -   Use types from ``collections.abc`` instead of ``typing``. :pr:`150`
 -   Fully specify exported types as reported by pyright. :pr:`152`
 

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -604,11 +604,11 @@ same signal.
 
 
 def __getattr__(name: str) -> t.Any:
-    if name == "reciever_connected":
+    if name == "receiver_connected":
         warnings.warn(
-            "The global 'reciever_connected' signal is deprecated and will be"
+            "The global 'receiver_connected' signal is deprecated and will be"
             " removed in Blinker 1.9. Use 'Signal.receiver_connected' and"
-            " 'Signal.reciever_disconnected' instead.",
+            " 'Signal.receiver_disconnected' instead.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
Made a typo `reciever` instead of `receiver` for `blinker.base.receiver_connected`. The more likely `blinker.receiver_connected` import worked correctly.
