### PR TITLE
Fix "Exception ignored" in weakref callback during interpreter shutdown.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased
 -   Drop support for Python 3.8. :pr:`175`
 -   Remove previously deprecated ``__version__``, ``receiver_connected``,
     ``Signal.temporarily_connected_to`` and ``WeakNamespace``. :pr:`172`
+-   Skip weakref signal cleanup if the interpreter is shutting down.
+    :issue:`173`
 
 
 Version 1.8.2

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections.abc as c
+import sys
 import typing as t
 import weakref
 from collections import defaultdict
@@ -403,7 +404,10 @@ class Signal:
         """
 
         def cleanup(ref: weakref.ref[c.Callable[..., t.Any]]) -> None:
-            self._disconnect(receiver_id, ANY_ID)
+            # If the interpreter is shutting down, disconnecting can result in a
+            # weird ignored exception. Don't call it in that case.
+            if not sys.is_finalizing():
+                self._disconnect(receiver_id, ANY_ID)
 
         return cleanup
 


### PR DESCRIPTION
Closes #173. Under some circumstances "Exception ignored in: <function WeakMethod.__new__.<locals>._cb at 0x770cbdb5b9c0>" appears during interpreter shutdown.

Root cause is probably a weakref callback running here from an interpeter shutdown finalizer pass, and then calling _disconnect either causes the same weakref to be cleaned up again or calls into some other already-gone resource and triggers the error.

No test is added for this, as noted in the linked issue it seems to only appear under some particular ordering of finalizers. However, there should be minimal risk of regressions as `sys.is_finalizing()` is only set when the Python environment is going away.

Thanks for all your work on blinker!