### PR TITLE
drop support for python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,18 +1,10 @@
 name: Tests
 on:
   push:
-    branches:
-      - main
-      - '*.x'
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.rst'
+    branches: [main, stable]
+    paths-ignore: ['docs/**', '*.md', '*.rst']
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.rst'
+    paths-ignore: [ 'docs/**', '*.md', '*.rst' ]
 jobs:
   tests:
     name: ${{ matrix.name || matrix.python }}
@@ -21,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {python: '3.13'}
           - {python: '3.12'}
           - {python: '3.11'}
           - {python: '3.10'}
           - {python: '3.9'}
-          - {python: '3.8'}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 1.9.0
 
 Unreleased
 
+-   Drop support for Python 3.8. :pr:`175`
 -   Remove previously deprecated ``__version__``, ``receiver_connected``,
     ``Signal.temporarily_connected_to`` and ``WeakNamespace``. :pr:`172`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.urls]
 Documentation = "https://blinker.readthedocs.io"
@@ -50,14 +50,14 @@ source = ["blinker", "tests"]
 source = ["src", "*/site-packages"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 files = ["src/blinker", "tests"]
 show_error_codes = true
 pretty = true
 strict = true
 
 [tool.pyright]
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 include = ["src/blinker", "tests"]
 typeCheckingMode = "basic"
 

--- a/src/blinker/base.py
+++ b/src/blinker/base.py
@@ -12,8 +12,7 @@ from ._utilities import make_id
 from ._utilities import make_ref
 from ._utilities import Symbol
 
-if t.TYPE_CHECKING:
-    F = t.TypeVar("F", bound=c.Callable[..., t.Any])
+F = t.TypeVar("F", bound=c.Callable[..., t.Any])
 
 ANY = Symbol("ANY")
 """Symbol for "any sender"."""
@@ -477,18 +476,7 @@ class NamedSignal(Signal):
         return f"{base[:-1]}; {self.name!r}>"  # noqa: E702
 
 
-if t.TYPE_CHECKING:
-
-    class PNamespaceSignal(t.Protocol):
-        def __call__(self, name: str, doc: str | None = None) -> NamedSignal: ...
-
-    # Python < 3.9
-    _NamespaceBase = dict[str, NamedSignal]  # type: ignore[misc]
-else:
-    _NamespaceBase = dict
-
-
-class Namespace(_NamespaceBase):
+class Namespace(dict[str, NamedSignal]):
     """A dict mapping names to signals."""
 
     def signal(self, name: str, doc: str | None = None) -> NamedSignal:
@@ -504,12 +492,16 @@ class Namespace(_NamespaceBase):
         return self[name]
 
 
+class _PNamespaceSignal(t.Protocol):
+    def __call__(self, name: str, doc: str | None = None) -> NamedSignal: ...
+
+
 default_namespace: Namespace = Namespace()
 """A default :class:`Namespace` for creating named signals. :func:`signal`
 creates a :class:`NamedSignal` in this namespace.
 """
 
-signal: PNamespaceSignal = default_namespace.signal
+signal: _PNamespaceSignal = default_namespace.signal
 """Return a :class:`NamedSignal` in :data:`default_namespace` with the given
 ``name``, creating it if required. Repeated calls with the same name return the
 same signal.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{12,11,10,9,8}
+    py3{13,12,11,10,9}
     style
     typing
     docs


### PR DESCRIPTION
Python 3.8 is EOL https://devguide.python.org/versions/